### PR TITLE
chore: update base URL to /rss-reader-angular

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -169,7 +169,7 @@
         "deploy": {
           "builder": "angular-cli-ghpages:deploy",
           "options": {
-            "baseHref": "/rss-reader/"
+            "baseHref": "/rss-reader-angular/"
           }
         }
       }

--- a/projects/rss-reader/src/assets/feedurls-schema.json
+++ b/projects/rss-reader/src/assets/feedurls-schema.json
@@ -1,7 +1,7 @@
 {
   "definitions": {},
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://edricchan03.github.io/rss-reader/schemas/feedurls.json",
+  "$id": "http://edricchan03.github.io/rss-reader-angular/schemas/feedurls.json",
   "type": "object",
   "properties": {
     "$schema": {

--- a/projects/rss-reader/src/assets/release-notes/release-notes-schema.json
+++ b/projects/rss-reader/src/assets/release-notes/release-notes-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://edricchan03.github.io/rss-reader/schemas/release-notes-schema.json",
+  "$id": "http://edricchan03.github.io/rss-reader-angular/schemas/release-notes-schema.json",
   "title": "Release notes JSON schema",
   "type": "object",
   "properties": {

--- a/projects/rss-reader/src/assets/release-notes/release-notes.json
+++ b/projects/rss-reader/src/assets/release-notes/release-notes.json
@@ -19,7 +19,7 @@
         "- Under-the-hood improvements",
         "- Increased social distancing by 150%",
         "- Added support for purchasing digital toilet paper",
-        "- (For a full list of changes, view the diff between `v1.6.0` and this release [here](https://github.com/EdricChan03/rss-reader/compare/v1.6.0...v1.6.1))"
+        "- (For a full list of changes, view the diff between `v1.6.0` and this release [here](https://github.com/EdricChan03/rss-reader-angular/compare/v1.6.0...v1.6.1))"
       ],
       "releaseAuthor": "EdricChan03",
       "releaseDate": "2020-03-27T20:38:00+0000"

--- a/projects/rss-reader/src/environments/environment.prod.ts
+++ b/projects/rss-reader/src/environments/environment.prod.ts
@@ -2,5 +2,5 @@ import { mergeWithDefaultEnv } from '../environment.base';
 
 export const environment = mergeWithDefaultEnv({
   production: true,
-  swLocation: '/rss-reader/ngsw-worker.js'
+  swLocation: '/rss-reader-angular/ngsw-worker.js'
 });

--- a/projects/rss-reader/src/manifest.webmanifest
+++ b/projects/rss-reader/src/manifest.webmanifest
@@ -5,15 +5,15 @@
   "theme_color": "#3f51b5",
   "background_color": "#fafafa",
   "display": "standalone",
-  "scope": "/",
-  "start_url": "/",
+  "scope": "/rss-reader-angular",
+  "start_url": "/rss-reader-angular",
   "categories": ["news"],
   "description": "News and RSS reader application that provides the latest news and headlines.",
   "dir": "auto",
   "lang": "en",
   "serviceworker": {
-    "src": "/rss-reader/ngsw-worker.js",
-    "scope": "/rss-reader/"
+    "src": "/rss-reader-angular/ngsw-worker.js",
+    "scope": "/rss-reader-angular/"
   },
   "icons": [
     {


### PR DESCRIPTION
Updates the base href of the application to use /rss-reader-angular instead of /rss-reader.

URLs should now point to https://edricchan03.github.io/rss-reader-angular instead of https://edricchan03.github.io/rss-reader.

(also adds an actual scope to the web manifest to specify what URLs should be part of the app)
(Hopefully the service worker shouldn't break anything :P)
